### PR TITLE
Expose input for specifying TF version + miscellaneous cleanup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
-    - uses: hashicorp/setup-terraform@v2
+    - uses: hashicorp/setup-terraform@v3
       with:
         terraform_wrapper: false
         terraform_version: ${{ inputs.terraform-version }}

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
     - uses: hashicorp/setup-terraform@v3

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
   working-directory:
     description: Working directory.
     default: ./
+  terraform-version:
+    description: Terraform version.
+    default: "latest"
 runs:
   using: composite
   steps:
@@ -50,6 +53,7 @@ runs:
     - uses: hashicorp/setup-terraform@v2
       with:
         terraform_wrapper: false
+        terraform_version: ${{ inputs.terraform-version }}
     - run: ${{ github.action_path }}/convert.sh ${{ inputs.file }} ${{ inputs.label }}
       env:
         ORIENTATION: ${{ inputs.orientation }}

--- a/convert.sh
+++ b/convert.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
-temp=$(mktemp $1.XXXXXXXXXX)
+temp=$(mktemp "$1.XXXXXXXXXX")
 
 terraform init -backend=false
-terraform graph | node $(dirname $0)/index.mjs $1 $2 > $temp
-mv $temp $1
+terraform graph | node "$(dirname "$0")/index.mjs" "$1" "$2" > "$temp"
+mv "$temp" "$1"


### PR DESCRIPTION
👋 Hi @asannou - thanks for `tfmermaid-action`! Most significantly, this PR addresses issue #2 by exposing an input through which uses can specify the desired Terraform version for `tfmermaid-action` to use.

As a bonus, this PR also takes care of some additional cleanup:

* upgrades `setup-terraform` to v3
* upgrades `setup-node` to v4
* consistently use `bash` to run `convert.sh` (use bash in both `convert.sh`'s shebang, as well as
  `action.yml`'s `shell: bash` specification)
* fix the following [shellcheck](https://www.shellcheck.net/) complaints with `convert.sh`:

```
$ shellcheck convert.sh

In convert.sh line 5:
temp=$(mktemp $1.XXXXXXXXXX)
              ^-- SC2086 (info): Double quote to prevent globbing and
word splitting.

Did you mean:
temp=$(mktemp "$1".XXXXXXXXXX)

In convert.sh line 8:
terraform graph | node $(dirname $0)/index.mjs $1 $2 > $temp
                       ^-----------^ SC2046 (warning): Quote this to
prevent word splitting.
                                 ^-- SC2086 (info): Double quote to
prevent globbing and word splitting.
                                               ^-- SC2086 (info): Double
quote to prevent globbing and word splitting.
                                                  ^-- SC2086 (info):
Double quote to prevent globbing and word splitting.
                                                       ^---^ SC2086
(info): Double quote to prevent globbing and word splitting.

Did you mean:
terraform graph | node $(dirname "$0")/index.mjs "$1" "$2" > "$temp"

In convert.sh line 9:
mv $temp $1
   ^---^ SC2086 (info): Double quote to prevent globbing and word
splitting.
         ^-- SC2086 (info): Double quote to prevent globbing and word
splitting.

Did you mean:
mv "$temp" "$1"

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word
splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent
globbing ...
```

  